### PR TITLE
bug identified and resolved - page refresh w/ tasks in done lane 

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -159,7 +159,9 @@ const coordinateTaskColor = (dateEl) => {
     let difference = tDay.diff(coordinateTaskColor, "day", true);
 
     // evaluate bread crumb date and apply determine the class for colorization
-    if (difference > 1) {
+    if( task.progState === "done") { 
+        return "future"
+    } else if (difference > 1) {
         return "pastdue";
     } else if (difference > 0 && difference <= 1) {
         return "today";


### PR DESCRIPTION
When the user refreshes the page after moving a task to 'done' the colorization of the bread crumb task would reset based on the date criteria. An additional line of logic was appended to the coordinateTaskColor function to handle when a task has received the progState of done. *note - progState referrers to the JSON key that represents the lane a given bread crumb is in.  