### PR TITLE
resolved bug to re-colorize bread crumbs when moved out of done lane

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -197,10 +197,11 @@ $(document).ready(function () {
             // save the new progState to the json object 
             localStorage.setItem("tasks", JSON.stringify(taskList));
 
-
             // color update when moved to done lane
             if (newProgState === "done") {
                 $(ui.draggable).addClass("future");
+            } else if (newProgState === "in-progress" || "to-do") {
+                location.reload();
             }
             // append the breadcrumb to the new lane
             ui.draggable.detach().appendTo($(this));


### PR DESCRIPTION
When a user moves a bread crumb from the done lane to an alternate lane, the done colorization was not restored. This is now resolved with additional logic applied to the ready function. In order to retrigger the dayjs calculation when a progState is other than 'done' a page refresh has been implemented, which retriggers the dayjs calculation. 